### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for executing Strands agents. This project provides a simple way to integrate Strands agents with Amazon Q and other MCP-compatible systems.
 
+<a href="https://glama.ai/mcp/servers/@imgaray/strands-agents-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imgaray/strands-agents-mcp/badge" alt="Strands Agent MCP server" />
+</a>
+
 ## Overview
 
 Strands Agent MCP is a bridge between the Strands agent framework and the Model Context Protocol (MCP). It allows you to:


### PR DESCRIPTION
This PR adds a badge for the [Strands Agent MCP](https://glama.ai/mcp/servers/@imgaray/strands-agents-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@imgaray/strands-agents-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@imgaray/strands-agents-mcp/badge" alt="Strands Agent MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.